### PR TITLE
Include CMB2 the correct way.

### DIFF
--- a/controllers/Plugin.php
+++ b/controllers/Plugin.php
@@ -416,21 +416,15 @@ class PdfLightViewer_Plugin {
 		
 	public static function run() {
 		// third party
-			if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
-				include_once(PDF_LIGHT_VIEWER_APPPATH.'/vendor/autoload.php');
-			}
-			
-			function wp_pdf_light_viewer_cmb_initialize_cmb_meta_boxes() {
-                if (!is_admin()) {
-                    return;
-                }
-                
-				require_once PDF_LIGHT_VIEWER_APPPATH.'/vendor/webdevstudios/cmb2/init.php';
-                require_once PDF_LIGHT_VIEWER_APPPATH.'/vendor/webdevstudios/cmb2/bootstrap.php';
-			}
-			add_action('init', 'wp_pdf_light_viewer_cmb_initialize_cmb_meta_boxes', 9999);
-			
-			include_once(PDF_LIGHT_VIEWER_APPPATH.'/libraries/directory_helper.php');
+		if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
+			include_once(PDF_LIGHT_VIEWER_APPPATH.'/vendor/autoload.php');
+		}
+		
+		if (is_admin()) {
+			require_once PDF_LIGHT_VIEWER_APPPATH.'/vendor/webdevstudios/cmb2/init.php';
+		}
+		
+		include_once(PDF_LIGHT_VIEWER_APPPATH.'/libraries/directory_helper.php');
 		
 		// 	
 		if (!class_exists('PdfLightViewer_AssetsController')) {


### PR DESCRIPTION
This is the proper way to include CMB2. It needs to be included before the 'init' action, so the 'after_setup_theme' here is fine.
You should never be including any CMB2 files directly other than the init.php file. By directly requiring bootstrap.php, you will cause fatal errors like [this reporter mentioned](https://wordpress.org/support/topic/fatal-error-after-installing-6) as well as breaking the CMB2 preferential loader.